### PR TITLE
Fix documentation typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Compiled Lua sources
 docs/build/index.html
-builder
+docs/builder/builder
 luac.out
 lib/audiowaveform
 lib/acrostic/acrostic

--- a/docs/builder/content/blurbs/tli.md
+++ b/docs/builder/content/blurbs/tli.md
@@ -57,7 +57,7 @@ Ties are special too, because they can continue onto the next line. If you want 
 
 <h2 class="h2under" id="subdivisions">Example 5 (subdivisions)</h2>
 
-Parentheses can be used to define subdivisions which can save space instead of entering many resets. Each enclosed set of parentheses is considered a single entity for the purposes of dividing by the number of entities per line. For example, consider the following:
+Parentheses can be used to define subdivisions which can save space instead of entering many rests. Each enclosed set of parentheses is considered a single entity for the purposes of dividing by the number of entities per line. For example, consider the following:
 
 <p class="shiny">(c d) e</p>
 

--- a/docs/builder/content/clades/slicer.md
+++ b/docs/builder/content/clades/slicer.md
@@ -7,6 +7,6 @@ weight: 1.0
 
 The `drum` is designed to easily slice and truncate audio. This clade is special in that it does note use note or chord syntax, but **it uses [hex](#hex) syntax** which defines the position of the slice (`0-f`). 
 
-The slices can be moved around in the sample screen which can be accessed by pressing *tab*. In this screen you can select slices with *shift* + *left*/*right* and adjust them with *left* or *right*. You can zoom in with *up* or *down*. You can easily import samples. Samples are added simpy using the *ctrl* + *o* combination. Slices can be deleted with the `delete` key. See all the invocations in the [sample invocations](#sample-view).
+The slices can be moved around in the sample screen which can be accessed by pressing *tab*. In this screen you can select slices with *shift* + *left*/*right* and adjust them with *left* or *right*. You can zoom in with *up* or *down*. You can easily import samples. Samples are added simply by using the *ctrl* + *o* combination. Slices can be deleted with the `delete` key. See all the invocations in the [sample invocations](#sample-view).
 
 The `drum` clade also features a additive synthesizer kick drum that can be integrated into the slices. The kick drum parameters are in `PARAMS > KICK`. This drum synth can be activated on any slice by going to a slice in the sample view mode and turning *E1* to change the volume of the kick to something > -48 dB.

--- a/docs/builder/content/commands/mover.md
+++ b/docs/builder/content/commands/mover.md
@@ -29,4 +29,4 @@ c4 mv10,-10,0
 c4 v-5
 </pre>
 
-Note that the miniumum and the maximum pertain to that particular command (in this example it is the volume).
+Note that the minimum and the maximum pertain to that particular command (in this example it is the volume).

--- a/docs/builder/content/commands/note.md
+++ b/docs/builder/content/commands/note.md
@@ -18,7 +18,7 @@ Individual notes are specified using lowercase scale letters (“a” through �
 
 Chords are specified by starting with an uppercase letter ("A" through "G") and then defining the chord flavor. The octave can be specified by including a `;<octave>` to the end of the command.
 
-Notes are only applicable on clades that can be specified by musical notes (rather than positions). See [Hex](#hex) for specifing positions.
+Notes are only applicable on clades that can be specified by musical notes (rather than positions). See [Hex](#hex) for specifying positions.
 
 ## Notes example
 

--- a/docs/builder/content/lessons/random.md
+++ b/docs/builder/content/lessons/random.md
@@ -10,7 +10,7 @@ clades:
     - crow
 ---
 
-Ordered command values can be applied by separting values by `.` (no spaces). For example if you want to pan alternating between left and right you can do `w-50,50` which will select `-50%` and then `50%`.
+Ordered command values can be applied by separating values by `.` (no spaces). For example if you want to pan alternating between left and right you can do `w-50,50` which will select `-50%` and then `50%`.
 
 Random command values can be applied by separating values by `,` (no spaces). For example, if you want to pan randomly between the left and right side you can do `w-50,50` which will select either `-50%` or `50%`. You can also randomize with whole sequential arrays by using the `:`. You can randomize a note between the first twelve semitones using the command `n1:12`. You can also combine these two, so you can select several numbers or within a range. For example, if you want to decimate sometimes between 50% and 75%, or sometimes not at all you can do `j0,0,0,50:75`. There are multiple `0` here, so that those values have more weight when selected randomly.
 

--- a/docs/builder/content/routing/mixer.md
+++ b/docs/builder/content/routing/mixer.md
@@ -4,6 +4,6 @@ title: Mixer
 
 <img src="/static/mixer.png" class="fr">
 
-There is a high level way to manage levels of various parameters by using the mixer page. You can open this page at any time by pressing *ctrl* + *L*. The screen that appears will dispaly a particular parameter (labeled at the top), for each of the 10 tracks. Next to this bar will be two grayed bars that show the current audio output for that given track (effects are not taken to account here though). 
+There is a high level way to manage levels of various parameters by using the mixer page. You can open this page at any time by pressing *ctrl* + *L*. The screen that appears will display a particular parameter (labeled at the top), for each of the 10 tracks. Next to this bar will be two grayed bars that show the current audio output for that given track (effects are not taken to account here though). 
 
 To use this page you can use *E2* to change the parameter modulated and *E3* to change the amount of modulation when changing it. Then you can use the keybard to modulate parameters - *0-9* will increase and *Q-P* will decrease the parameter respectively for each track. For example, you can hold *1* to increase the parameter for track 1, or hold *Q* to decrease it.

--- a/docs/builder/content/routing/zeverb.md
+++ b/docs/builder/content/routing/zeverb.md
@@ -4,7 +4,7 @@ title: Zeverb
 
 <img src="/static/zeverb.png" class="fr">
 
-Any clade can route its output through the "Zeverb" reverb effect. This is a reverb specific to *zxcvbn*. The majority of this reverb is written by [Jean Pierre Cimalando](https://github.com/jpcima), based on the reverbator by [Jon Dattorro](https://ccrma.stanford.edu/~dattorro/EffectDesignPart1.pdf). The reverb has been ammended with a shimmer.
+Any clade can route its output through the "Zeverb" reverb effect. This is a reverb specific to *zxcvbn*. The majority of this reverb is written by [Jean Pierre Cimalando](https://github.com/jpcima), based on the reverbator by [Jon Dattorro](https://ccrma.stanford.edu/~dattorro/EffectDesignPart1.pdf). The reverb has been amended with a shimmer.
 
 In each clade you can define the send to the reverb with `PARAMS > send reverb`, from 0 to 100%. The send for the zeverb exists as a command ([z](#zeverb)).
 


### PR DESCRIPTION
I also adjusted .gitignore as it was catching the entire builder directory and Git was complaining about it.