### PR TITLE
Version 2.3.0

### DIFF
--- a/docs/builder/content/changelog/v2.3.0.md
+++ b/docs/builder/content/changelog/v2.3.0.md
@@ -1,0 +1,9 @@
+---
+version: v2.3.0
+---
+- **NEW** added [midi start/stop](#midi)
+- **NEW** added [lfo shape parameter](#mover)
+- **NEW** added [midi cc command](#midi)
+- **NEW** added ["save to cursor file"](#menu-invocation)
+- **FIX** possible problem with CPU percentage not showing up after last update
+- **FIX** fixed spelling error of Decimate parameter

--- a/docs/builder/content/clades/midi.md
+++ b/docs/builder/content/clades/midi.md
@@ -5,4 +5,4 @@ weight: 8.0
 
 <img src="/static/midi1.png" class="fr">
 
-Midi devices can also be controlled. Midi devices accept pitch information. You can select the midi clade, and then below that you can select the device and the channel output. (Note the volume still appears as `dB` but it is automatically scaled as midi values).
+Midi devices can also be controlled. Midi devices accept pitch information. You can select the midi clade, and then below that you can select the device and the channel output. (Note the volume still appears as `dB` but it is automatically scaled as midi values). There is additionally a cc parameter that sends midi cc value every note that can be set via the TLI with shortcode 'j' or in the parameters menu. MIDI start/stop messages are also sent to the current MIDI device in the clade when CTRL+SPACE is used to start and stop all the clades.

--- a/docs/builder/content/commands/just-for.md
+++ b/docs/builder/content/commands/just-for.md
@@ -19,3 +19,5 @@ The [drum](#drum) this command will change the amount of decimation between 0 an
 For [mx.synths](#mx-synths) this command will change the four mods. Each mod has a range of 100 (which is mapped to -1 to 1). So for mod1, the values are 0-100, for mod2 the values are 101-200, etc.
 
 For [infinite pad](#infinite-pad) this command will change the swell. The range is 0 to 100%.
+
+For [MIDI](#midi) this command will send a CC message to the relative MIDI device and channel. The range is 0 to 127.

--- a/docs/builder/content/commands/mover.md
+++ b/docs/builder/content/commands/mover.md
@@ -19,6 +19,7 @@ clades:
 Mover is a special command that enacts a LFO on almost any of the other commands. Its syntax is different than all the other commands. It requires specifying the one-letter character of the command that is to be modified and a period (in beats). Then, optionallyl, a minimum and maximum can be specified.
 
 The mover LFO is only implemented until the command that is being modified is coded in another cell.
+LFO shape can also be changed to 'sine', 'triangle', 'saw', 'square' or 'random' at the bottom of the settings page.
 
 ## Example 1
 

--- a/docs/builder/content/commands/mover.md
+++ b/docs/builder/content/commands/mover.md
@@ -19,7 +19,7 @@ clades:
 Mover is a special command that enacts a LFO on almost any of the other commands. Its syntax is different than all the other commands. It requires specifying the one-letter character of the command that is to be modified and a period (in beats). Then, optionallyl, a minimum and maximum can be specified.
 
 The mover LFO is only implemented until the command that is being modified is coded in another cell.
-LFO shape can also be changed to 'sine','saw', 'square' or 'random' at the bottom of the settings page.
+LFO shape can also be changed to 'sine', 'saw', 'square' or 'random' at the bottom of the settings page.
 
 ## Example 1
 

--- a/docs/builder/content/commands/mover.md
+++ b/docs/builder/content/commands/mover.md
@@ -19,7 +19,7 @@ clades:
 Mover is a special command that enacts a LFO on almost any of the other commands. Its syntax is different than all the other commands. It requires specifying the one-letter character of the command that is to be modified and a period (in beats). Then, optionallyl, a minimum and maximum can be specified.
 
 The mover LFO is only implemented until the command that is being modified is coded in another cell.
-LFO shape can also be changed to 'sine', 'triangle', 'saw', 'square' or 'random' at the bottom of the settings page.
+LFO shape can also be changed to 'sine','saw', 'square' or 'random' at the bottom of the settings page.
 
 ## Example 1
 

--- a/docs/builder/template.html
+++ b/docs/builder/template.html
@@ -969,6 +969,16 @@
                 <td class="w25"><em>←</em>/<em>→</em></td>
                 <td class="w50">Changes the position of the current slice.</td>
             </tr>
+            <tr class="hrw hrt">
+                <td class="w25 bold">Save slice positions</td>
+                <td class="w25"><em>ctrl</em> + <em>s</em></td>
+                <td class="w50">Saves current positions of slices/onsets to cursor file</td>
+            </tr>
+            <tr class="hrw hrt">
+                <td class="w25 bold">Re-detect onsets</td>
+                <td class="w25"><em>ctrl</em> + <em>d</em></td>
+                <td class="w50">Re-detects onsets if no cursor file exist, otherwise loads cursor file again</td>
+            </tr>
         </table>
         <div>
             <hr class="hrgreen">

--- a/lib/installer.lua
+++ b/lib/installer.lua
@@ -12,7 +12,7 @@ function Installer:init()
   self.blinky=0
   self.k3debounce=true
   self.fade_in=0
-  show_message("v2.2.0",3000)
+  show_message("v2.3.0",3000)
 end
 
 function Installer:do_install()

--- a/lib/sample.lua
+++ b/lib/sample.lua
@@ -425,6 +425,8 @@ function Sample:keyboard(k,v)
     self:delta_cursor(1)
   elseif k=="CTRL+D" and v==1 then
     self:get_onsets()
+  elseif k=="CTRL+S" and v==1 then
+    self:save_cursors()
   elseif k=="LEFT" and v>0 then
     self:do_move(-1)
   elseif k=="RIGHT" and v>0 then
@@ -532,6 +534,15 @@ function Sample:get_render()
     os.execute(cmd)
   end
   return rendered
+end
+
+function Sample:save_cursors()
+  print("writing cursor file",self.path_to_cursors)
+  local file=io.open(self.path_to_cursors,"w+")
+  io.output(file)
+  io.write(json.encode({cursors=self.cursors}))
+  io.close(file)
+  show_message("cursors saved!")
 end
 
 function Sample:redraw()

--- a/zxcvbn.lua
+++ b/zxcvbn.lua
@@ -1,4 +1,4 @@
--- zxcvbn v2.2.0
+-- zxcvbn v2.3.0
 --
 --
 -- zxcvbn.norns.online


### PR DESCRIPTION
- **NEW** added [midi start/stop](#midi)
- **NEW** added [lfo shape parameter](#mover)
- **NEW** added [midi cc command](#midi)
- **NEW** added ["save to cursor file"](#menu-invocation)
- **FIX** possible problem with CPU percentage not showing up after last update
- **FIX** fixed spelling error of Decimate parameter

Been testing it for quite a while now. But I did hit some snags with /cr/lf and /lf formatting so let me know if that carries over.
I've re-downloaded my whole branch and it has correct line endings and everything works as it should :) 

I also tried my best to update all the wiki stuff, hopefully my edit of template.html works.
I'll keep a lookout for spelling errors and such and update if I see any.

Let me know if it all works!

- **Test MIDI start/stop**
Simply have a midi clade, set a device and push ctrl+space and it should send a start message and stop message when you stop or start everything.
- **lfo shape** is at the bottom of the param page :)
- **midi cc** has an enable button, midi cc number and midi cc value
- **save to cursor file**
 to test it, just load a drum chain, edit the cursors, push ctrl+s, edit the cursors again and then push ctrl+d to see if the file loads again 