### PR TITLE
Fix copy all paste all to copy by value not reference

### DIFF
--- a/lib/vterm.lua
+++ b/lib/vterm.lua
@@ -185,7 +185,7 @@ end
 
 function VTerm:copy_all()
   -- copy the current line
-  vterm_clipboard_all = self.lines
+  vterm_clipboard_all = self.lines[1]
   show_message("copied all")
 end
 
@@ -193,7 +193,7 @@ function VTerm:paste_all()
   if vterm_clipboard_all==nil then
     do return end
   end
-  self.lines = vterm_clipboard_all
+  self.lines[1] = vterm_clipboard_all
   self.history_dirty=true
   show_message("pasted all")
 end


### PR DESCRIPTION
Copy paste all was copying by reference and not value.
So if you copied from track1 to track2 for example, and then edit the text on track2 then the text for track1 would also change.
